### PR TITLE
Switch to xspec.io domain

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+xspec.io


### PR DESCRIPTION
Once the DNS is set up (per #4):

xspec.io. CNAME xspec.github.io.

(to be checked)