### PR TITLE
Add post for XSpec v2.0.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run a local version:
 * Clone or download this repository from GitHub.
 * Checkout the branch `hugo`: `git checkout hugo`
 * Install the git submodules: `git submodule update --init --recursive`
-* Run `hugo server -D` to get a local version of the website.
+* Run `hugo server -D` to get a local version of the website on [http://localhost:1313](http://localhost:1313)
 
 To submit updates: create a pull request to the `hugo` branch.
 

--- a/content/posts/xspec_207_release.md
+++ b/content/posts/xspec_207_release.md
@@ -1,0 +1,38 @@
+---
+date: 2020-11-29
+linktitle: Release XSpec v2.0.7
+title: Release XSpec v2.0.7
+weight: 9
+categories: [ "Release" ]
+tags: ["v2.0.7"]
+---
+
+## Release XSpec v2.0.7
+Release v2.0.7 introduces new features and enhancements, fixes bugs, and improves the test suite and the documentation. These are the highlights for XSpec v2.0.7:
+
+#### **Common to Languages Under Test**
+- [`x:helper`](https://github.com/xspec/xspec/wiki/Integrating-Your-Own-Test-Helpers) lets you integrate your own test helpers
+- `@as` can be set in `x:context` and `x:expect`
+
+#### **XSLT**
+- You can test XSLT packages and static parameters ([experimental](https://github.com/xspec/xspec/wiki/External-Transformation))
+
+#### **Schematron**
+- Compatible with [SchXslt](https://github.com/schxslt/schxslt) (not thoroughly tested)
+- You can write advanced expressions in `@location` (e.g. `<x:expect-assert location="//sec[@id='lower']" />`)
+
+#### **XQuery**
+- [Text value templates](https://github.com/xspec/xspec/wiki/Text-Value-Templates)
+- Arrays and maps are reported in the same way as XSLT scenarios
+
+#### **Command Line**
+- New option `-e` treats failed tests as error
+
+#### **Oxygen**
+- `${xmlCatalogFilesList}` takes effect in the **Run XSpec Test** transformation scenario
+
+#### **Breaking Changes**
+- See https://github.com/xspec/xspec/issues/1121
+
+
+Many thanks to the many XSpec contributors who made this release possible. They are listed on the [release notes](https://github.com/xspec/xspec/releases/tag/v2.0.7).


### PR DESCRIPTION
## Summary
This PR adds a new post to promote the XSpec v2.0.7 release. It also updates the README with the link to see the local version of the Hugo website, I thought it may be useful for people not familiar with Hugo. 

I generated a local copy from the branch and the post looks like this:

![image](https://user-images.githubusercontent.com/13256236/100554402-4044e800-328c-11eb-8d6f-a95d15de900f.png)
