### PR TITLE
Add post XSpec v2.2.4 release

### DIFF
--- a/content/posts/xspec_224_release.md
+++ b/content/posts/xspec_224_release.md
@@ -1,0 +1,29 @@
+---
+date: 2021-10-08
+linktitle: Release XSpec v2.2.4
+title: Release XSpec v2.2.4
+weight: 7
+categories: [ "Release" ]
+tags: ["v2.2.4"]
+---
+
+## Release XSpec v2.2.4
+Release v2.2.4 introduces new features and enhancements, fixes bugs, and improves the test suite and the documentation. These are the highlights for XSpec v2.2.4:
+
+#### Common to Languages Under Test
+
+- Pending or unfocused variable declarations are handled more gracefully.
+- Large results are no longer saved in separate XML files by default.
+- This will be the last version to support Saxon 9.8.
+
+#### XSLT
+
+- Multiple test scenarios can be run in parallel by setting `@threads` on `x:description` or `x:scenario`. (Requires Saxon-EE)
+- You can set `x:context` when testing functions. (Requires `/x:description/@run-as`=`external`)
+
+#### Schematron
+
+- You can mark assertions as pending by setting `@pending` on `x:expect-*` elements, as an alternative to using the `x:pending` element.
+- When `@location` does not point to one node, the error message is more helpful.
+
+Many thanks to the many XSpec contributors who made this release possible. They are listed on the [release notes](https://github.com/xspec/xspec/releases/tag/v2.2.4).


### PR DESCRIPTION
## Summary
This PR adds a new post to promote the XSpec v2.2.4 release. 

I generated a local copy from the branch using Hugo 0.70.0 (same version used in GitHub Actions) and the post looks like this:

![image](https://user-images.githubusercontent.com/13256236/136527956-bd656960-ca1d-465c-a4f5-872a78103ea3.png)
