### PR TITLE
Add post XSpec v3.0.3 release

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -6,4 +6,4 @@ XSpec is a unit test and [behaviour-driven development](http://en.wikipedia.org/
 
 XSpec consists of a syntax for describing the behaviour of XSLT, XQuery, or Schematron code, and some code that enables you to test the code against those descriptions.
 
-To get started, check out the installation instructions for [MacOS/Linux](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux) and [Windows](https://github.com/xspec/xspec/wiki/Installation-on-Windows) and how to [write your first XSpec test](https://github.com/xspec/xspec/wiki/Getting-Started).
+To get started, check out the installation instructions for [macOS/Linux](https://github.com/xspec/xspec/wiki/Installation-on-Mac-and-Linux) and [Windows](https://github.com/xspec/xspec/wiki/Installation-on-Windows) and how to [write your first XSpec test](https://github.com/xspec/xspec/wiki/Getting-Started).

--- a/content/help/index.md
+++ b/content/help/index.md
@@ -2,4 +2,4 @@
 title = "Get Help"
 +++
 
-Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki). If you have any question which is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues) or post it in the [XSpec discussion list](http://groups.google.com/group/xspec-users).
+Check out the XSpec documentation in the [wiki](https://github.com/xspec/xspec/wiki). If you have any question that is not answered in the wiki, feel free to [raise an issue](https://github.com/xspec/xspec/issues).

--- a/content/posts/xspec_303_release.md
+++ b/content/posts/xspec_303_release.md
@@ -1,0 +1,36 @@
+---
+date: 2024-04-16
+linktitle: Release XSpec v3.0.3
+title: Release XSpec v3.0.3
+weight: 6
+categories: [ "Release" ]
+tags: ["v3.0.3"]
+---
+
+<a href="https://github.com/xspec/xspec/issues/1766"><img align="right" src="https://user-images.githubusercontent.com/10128303/262700963-1a1e0fda-f335-4c90-9f8a-f72c5ece6c27.png" width="100px" alt="XSpec logo proposed and discussed in #1766" /></a>
+
+## Release XSpec v3.0.3
+Release v3.0 upgrades its connections with related software. Support for testing Schematron schemas now uses SchXslt as the built-in Schematron implementation. XSLT code coverage is compatible with Saxon 12.4 or later. These are the highlights of XSpec v3.0:
+
+#### Common to Languages Under Test
+
+- XSpec is tested with Saxon 12, 11, and 10, while use of Saxon versions earlier than 12.4 is not recommended.
+- XSpec no longer supports Saxon 9.
+- When comparing XML, you can ignore some or all attributes using three-dot syntax `x:attrs="..."`.
+- XPath function items stored in global variables are testable using syntax `<x:call function="my-function" call-as="variable">`.
+
+#### XSLT
+
+- XSLT code coverage feature is compatible with Saxon 12.4. **Compatibility note:** This upgrade is not backward compatible with earlier Saxon versions.
+- XSpec experimentally supports testing with XSLT 4.0 and XPath 4.0. Set `xslt-version="4.0"` on `x:description`, and use an XSLT processor that has support for 4.0 enabled.
+
+#### XQuery
+
+- XSpec experimentally supports testing with XQuery 4.0 and XPath 4.0. Set `xquery-version="4.0"` on `x:description`, and use an XQuery processor that has support for 4.0.
+
+#### Schematron
+
+- SchXslt 1.9.5 replaces the skeleton implementation because the latter is no longer maintained. **Compatibility note:** Some XSpec tests might produce different results with SchXslt.
+- XSpec scenarios can verify the text of messages or diagnostics. Add expected text inside `x:expect-assert` or `x:expect-report`.
+
+Many thanks to all the XSpec contributors who made this release possible!  They are listed in the [release notes](https://github.com/xspec/xspec/releases/tag/v3.0.3).

--- a/content/posts/xspec_303_release.md
+++ b/content/posts/xspec_303_release.md
@@ -1,5 +1,5 @@
 ---
-date: 2024-04-16
+date: 2024-04-17
 linktitle: Release XSpec v3.0.3
 title: Release XSpec v3.0.3
 weight: 6
@@ -10,7 +10,7 @@ tags: ["v3.0.3"]
 <a href="https://github.com/xspec/xspec/issues/1766"><img align="right" src="https://user-images.githubusercontent.com/10128303/262700963-1a1e0fda-f335-4c90-9f8a-f72c5ece6c27.png" width="100px" alt="XSpec logo proposed and discussed in #1766" /></a>
 
 ## Release XSpec v3.0.3
-Release v3.0 upgrades its connections with related software. Support for testing Schematron schemas now uses SchXslt as the built-in Schematron implementation. XSLT code coverage is compatible with Saxon 12.4 or later. These are the highlights of XSpec v3.0:
+Release v3.0.3 upgrades its connections with related software. Support for testing Schematron schemas now uses SchXslt as the built-in Schematron implementation. XSLT code coverage is compatible with Saxon 12.4 or later. These are the highlights of XSpec v3.0:
 
 #### Common to Languages Under Test
 
@@ -21,7 +21,7 @@ Release v3.0 upgrades its connections with related software. Support for testing
 
 #### XSLT
 
-- XSLT code coverage feature is compatible with Saxon 12.4. **Compatibility note:** This upgrade is not backward compatible with earlier Saxon versions.
+- XSLT code coverage feature is compatible with Saxon 12.4. **Compatibility note:** This upgrade is not backward compatible with earlier Saxon versions. Also, Saxon 12.4 does not report some `xsl:sequence` instructions that are actually hit.
 - XSpec experimentally supports testing with XSLT 4.0 and XPath 4.0. Set `xslt-version="4.0"` on `x:description`, and use an XSLT processor that has support for 4.0 enabled.
 
 #### XQuery


### PR DESCRIPTION
This PR adds a new post to promote the XSpec v3.0.3 release. I'll change this from Draft to Ready when the actual release is public, to avoid premature announcement.

The PR also makes a few minor text changes for things I noticed while I was here, similar to https://github.com/xspec/xspec/pull/1905.

I generated a local copy from the branch using `C:/Hugo/bin/hugo server -D  --buildFuture` (where `--buildFuture` was needed because the date of my new post is in the future) and took some screen captures.

Cc: @cirulls, @rolfkleef, @AirQuick 

### Main page

![Screenshot 2024-04-11 151018](https://github.com/xspec/xspec.github.io/assets/40716346/8d1d9d8d-6fdb-43b0-af7e-c5538df683a2)

### New post, in two pieces because it's tall

![Screenshot 2024-04-11 151053](https://github.com/xspec/xspec.github.io/assets/40716346/fef2deea-ea73-4ace-99ff-323a5cc3a4f1)

Lower part, after scrolling...

![Screenshot 2024-04-11 151114](https://github.com/xspec/xspec.github.io/assets/40716346/a1708659-39a9-4a07-b924-891f035ecf88)

### List of versions

![Screenshot 2024-04-11 151147](https://github.com/xspec/xspec.github.io/assets/40716346/134079c5-48da-4238-911d-b63b12db05e5)

