### PR TITLE
Oxygen add-on for XSpec v3.2.0

### DIFF
--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+	<head>
+		<title>XSpec</title>
+	</head>
+	<body>
+		<div>
+			<p>This add-on installs a recent snapshot of the <span style="color:red">development
+					version</span> of XSpec. See <a
+					href="https://github.com/xspec/xspec/wiki/Running-with-Oxygen">Wiki</a> for
+				details.</p>
+			<p>This add-on does <span style="color:red">not</span> work side by side with <b>XSpec
+					Framework</b> add-on (a companion add-on for <b>XSpec Helper view</b>
+				add-on).</p>
+		</div>
+		<div>
+			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
+			<div>
+				<h3>v3.2.0</h3>
+				<ul>
+					<li>Test reports use black text on white background by default, improving accessibility.
+						Themes 'whiteblack' (white on black) and 'classic' (earlier green/pink design) are
+						also available. (<a href="https://github.com/xspec/xspec/pull/1822">#2055</a>)</li>
+					<li>Tests for Schematron can verify string values of Schematron properties
+						(<a href="https://github.com/xspec/xspec/pull/1822">#2045</a>).</li>
+					<li>Tested with BaseX 11.6</li>
+					<li>Tested with Oxygen 27.0.</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.1.3</h3>
+				<ul>
+					<li>Fix for <a href="https://github.com/xspec/xspec-maven-plugin-1/">xspec/xspec-maven-plugin-1</a> and other uses
+						of XSpec from a .zip or .jar file</li>
+					<li>SchXslt 1.10.1 replaces 1.10 as the built-in Schematron implementation</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.1.2</h3>
+				<ul>
+					<li>Official release of v3.1</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.1.1</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>fix(report): XSLT code coverage reports for Saxon 12.4 have many bug fixes in the coverage status</li>
+					<li>feat(schematron): SchXslt 1.10 replaces 1.9.5 as the built-in Schematron implementation</li>
+					<li>Tested with Saxon 10.9, 11.6, and 12.5, except that detailed contents of XSLT code coverage reports are tested with Saxon 12.4</li>
+					<li>Tested with Oxygen 26.1</li>
+					<li>Tested with BaseX 11.3</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.0.3</h3>
+				<ul>
+					<li>Official release of v3.0</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.0.2</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>feat(xslt): code coverage for Saxon 12.4+ (<a href="https://github.com/xspec/xspec/pull/1833"
+							>#1833</a>)</li>
+					<li>Removes Saxon 9.9 support</li>
+					<li>Saxon versions earlier than 12.4 are no longer recommended</li>
+					<li>Tested with Saxon 10.9, 11.6, and 12.4</li>
+					<li>Tested with Oxygen 26.1</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.0.1</h3>
+				<ul>
+					<li>feat(schematron): SchXslt 1.9.5 replaces skeleton implementation</li>
+					<li>feat(schematron): verification of messages (<a href="https://github.com/xspec/xspec/pull/1822"
+							>#1822</a>)</li>
+					<li>feat: syntax to ignore some or all attributes (<a href="https://github.com/xspec/xspec/pull/1838"
+							>#1838</a>)</li>
+					<li>feat: experimental support for XSLT/XQuery/XPath 4.0 (<a href="https://github.com/xspec/xspec/pull/1883"
+							>#1883</a>)</li>
+				</ul>
+			</div>
+			<div>
+				<h3>v3.0.0</h3>
+				<ul>
+					<li>Initial development version of v3.0</li>
+					<li>Tested with Oxygen 26.0</li>
+				</ul>
+			</div>
+		</div>
+	</body>
+</html>

--- a/static/editors/oxygen/oxygen-addon.xml
+++ b/static/editors/oxygen/oxygen-addon.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xt:extensions xmlns:xi="http://www.w3.org/2001/XInclude"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:xt="http://www.oxygenxml.com/ns/extension"
+	xsi:schemaLocation="http://www.oxygenxml.com/ns/extension http://www.oxygenxml.com/ns/extension/extensions.xsd">
+
+	<!-- This @id value assumes that https://github.com/xspec/ community owns "xspec.io". -->
+	<xt:extension id="io.xspec.xspec">
+
+		<!--
+			To publish a new version,
+			* Update this @href to a specific commit archive
+			* Increment <xt:version>
+			* Disable the new add-on version in the project options stored in xspec.xpr
+			  (Options - Preferences - Document Type Association)
+			* Update the changelog in xt:description
+		-->
+		<xt:location
+			href="https://github.com/xspec/xspec/archive/fee92fd453ac9e55e3c889df168ebc918fdc8485.zip" />
+
+		<xt:version>3.2.0</xt:version>
+
+		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
+			* oXygen add-on and framework require manual testing.
+			* oXygen framework cannot always be backward compatible. See
+			  https://github.com/TEIC/oxygen-tei/issues/30. -->
+		<xt:oxy_version>24.1+</xt:oxy_version>
+
+		<xt:type>framework</xt:type>
+
+		<!-- This could be Jeni, but she's not participated in this add-on release. -->
+		<xt:author>https://github.com/xspec/xspec</xt:author>
+
+		<xt:name>XSpec</xt:name>
+
+		<xt:description>
+			<xi:include href="latest.xhtml">
+				<xi:fallback>Visit https://github.com/xspec/xspec and see
+					editors/oxygen/add-on/description/latest.xhtml</xi:fallback>
+			</xi:include>
+		</xt:description>
+
+		<xt:license><![CDATA[
+			The MIT License
+
+Copyright (c) 2008-2017 Jeni Tennison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+		]]></xt:license>
+
+	</xt:extension>
+
+</xt:extensions>


### PR DESCRIPTION
In https://github.com/xspec/xspec/issues/2075#issuecomment-2684172976, @cmarchand suggests publishing `oxygen-addon.xml` at xspec.io. This pull request does that for the existing v3.2.0 add-on for which Oxygen users would point Oxygen to the URL `https://github.com/xspec/xspec/raw/master/oxygen-addon.xml` ([instructions](https://github.com/xspec/xspec/wiki/Running-with-Oxygen#loading-xspec-via-oxygen-add-on)). The purpose of this PR is to make sure this new publishing location works and that we're happy with it, before asking users to change their Oxygen setting.

After this pull request is merged, Oxygen should be able to use the following URL to find and install the add-on: `https://xspec.io/editors/oxygen/oxygen-addon.xml`

I am open to suggestions about what the URL should be.

In this pull request,

- The oxygen-addon.xml file is from the top level of the xspec/xspec repo, and I made two changes: I flattened the XInclude pointing to LICENSE because a LICENSE file in this repo might look as if it's the license for this repo rather than the license for the XSpec add-on code. Also, I redirected the XInclude pointing to `latest.xhtml` to adapt to the shallower directory hierarchy in this repo.
- The `latest.xhtml` file is directly from the xspec/xspec repo, but I used a shallower directory hierarchy because it seemed simpler. The original file is at https://github.com/xspec/xspec/blob/0bef40c0dbed817717ff1b1a8043f367b368d33b/editors/oxygen/add-on/description/latest.xhtml

### Testing done

I was able to install the add-on in Oxygen 24.1 and Oxygen 27.0, after running hugo locally and giving Oxygen this URL:
http://localhost:1313/editors/oxygen/oxygen-addon.xml

In one case, I had the v3.1.3 add-on previously installed, and Oxygen removed the v3.1.3 add-on when unpacking the new one. It also recognized the new one as an update of the old one.

![image](https://github.com/user-attachments/assets/49d418e7-283d-43a7-8b8f-fa6650aabe20)
