### PR TITLE
Oxygen add-on for XSpec v3.2.1

### DIFF
--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -16,6 +16,15 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.2.1</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>Code coverage report includes Contents section with coverage statistics
+						(<a href="https://github.com/xspec/xspec/pull/2078">#2078</a>).</li>
+					<li>Tested with BaseX 11.7.</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.2.0</h3>
 				<ul>
 					<li>Test reports use black text on white background by default, improving accessibility.
@@ -80,13 +89,6 @@
 							>#1838</a>)</li>
 					<li>feat: experimental support for XSLT/XQuery/XPath 4.0 (<a href="https://github.com/xspec/xspec/pull/1883"
 							>#1883</a>)</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v3.0.0</h3>
-				<ul>
-					<li>Initial development version of v3.0</li>
-					<li>Tested with Oxygen 26.0</li>
 				</ul>
 			</div>
 		</div>

--- a/static/editors/oxygen/oxygen-addon.xml
+++ b/static/editors/oxygen/oxygen-addon.xml
@@ -9,16 +9,16 @@
 
 		<!--
 			To publish a new version,
-			* Update this @href to a specific commit archive
+			* Update this @href to a specific archive named after the version, e.g., v1.2.3.zip
 			* Increment <xt:version>
 			* Disable the new add-on version in the project options stored in xspec.xpr
 			  (Options - Preferences - Document Type Association)
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/fee92fd453ac9e55e3c889df168ebc918fdc8485.zip" />
+			href="https://github.com/xspec/xspec/archive/refs/tags/v3.2.1.zip" />
 
-		<xt:version>3.2.0</xt:version>
+		<xt:version>3.2.1</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
This pull request brings the work for #19 up to date with https://github.com/xspec/xspec/pull/2076 . I will update it again after releasing v3.2.2 with https://github.com/xspec/xspec/pull/2091 .

I was able to install the add-on in Oxygen 27.0, after running hugo locally and giving Oxygen this URL:
http://localhost:1313/editors/oxygen/oxygen-addon.xml