### PR TITLE
Oxygen add-on for XSpec v3.2.2

### DIFF
--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -16,6 +16,12 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.2.2</h3>
+				<ul>
+					<li>Official release of v3.2</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.2.1</h3>
 				<ul>
 					<li>Release Candidate of the stable release</li>
@@ -77,18 +83,6 @@
 					<li>Saxon versions earlier than 12.4 are no longer recommended</li>
 					<li>Tested with Saxon 10.9, 11.6, and 12.4</li>
 					<li>Tested with Oxygen 26.1</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v3.0.1</h3>
-				<ul>
-					<li>feat(schematron): SchXslt 1.9.5 replaces skeleton implementation</li>
-					<li>feat(schematron): verification of messages (<a href="https://github.com/xspec/xspec/pull/1822"
-							>#1822</a>)</li>
-					<li>feat: syntax to ignore some or all attributes (<a href="https://github.com/xspec/xspec/pull/1838"
-							>#1838</a>)</li>
-					<li>feat: experimental support for XSLT/XQuery/XPath 4.0 (<a href="https://github.com/xspec/xspec/pull/1883"
-							>#1883</a>)</li>
 				</ul>
 			</div>
 		</div>

--- a/static/editors/oxygen/oxygen-addon.xml
+++ b/static/editors/oxygen/oxygen-addon.xml
@@ -11,14 +11,12 @@
 			To publish a new version,
 			* Update this @href to a specific archive named after the version, e.g., v1.2.3.zip
 			* Increment <xt:version>
-			* Disable the new add-on version in the project options stored in xspec.xpr
-			  (Options - Preferences - Document Type Association)
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/refs/tags/v3.2.1.zip" />
+			href="https://github.com/xspec/xspec/archive/refs/tags/v3.2.2.zip" />
 
-		<xt:version>3.2.1</xt:version>
+		<xt:version>3.2.2</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
This pull request brings the Oxygen add-on up to date with https://github.com/xspec/xspec/pull/2091 .

### To do, in this order:

- [x] Merge https://github.com/xspec/xspec/pull/2091 into `master`. That will create the v3.2.2.zip file.
- [x] On the branch for this PR, run hugo locally and test installation of the add-on with local URL: http://localhost:1313/editors/oxygen/oxygen-addon.xml
- [ ] Merge this PR onto `hugo` branch.
- [ ] Uninstall add-on, and test re-installation with remote URL: https://xspec.io/editors/oxygen/oxygen-addon.xml