### PR TITLE
Add post for XSpec v3.2.2

### DIFF
--- a/content/posts/xspec_322_release.md
+++ b/content/posts/xspec_322_release.md
@@ -1,0 +1,31 @@
+---
+date: 2025-03-24
+linktitle: Release XSpec v3.2.2
+title: Release XSpec v3.2.2
+weight: 6
+categories: ["Release"]
+tags: ["v3.2.2"]
+---
+
+<a href="https://github.com/xspec/xspec/issues/1766"><img align="right" src="https://user-images.githubusercontent.com/10128303/262700963-1a1e0fda-f335-4c90-9f8a-f72c5ece6c27.png" width="100px" alt="XSpec logo proposed and discussed in #1766"/>
+</a>
+
+## Release XSpec v3.2.2
+
+XSpec 3.2 enhances its HTML reports with coverage statistics and a choice of color themes. These are the highlights of XSpec v3.2:
+
+## Common to Languages Under Test
+
+- Test reports use black text on white background by default, improving accessibility. Themes `'whiteblack'` (white on black) and `'classic'` (earlier green/pink design) are also available. You can select a non-default theme using the `xspec.html.report.theme` Ant property or, in the command line interface, the `XSPEC_HTML_REPORT_THEME` environment variable.
+
+## XSLT
+
+- Code coverage report includes a Contents section with coverage statistics and navigation links to module-specific sections of the report.
+
+## XQuery
+- XSpec is tested with BaseX 11.8.
+
+## Schematron
+- Tests for Schematron can verify string values of Schematron properties.
+
+Many thanks to all the XSpec contributors who made this release possible! They are listed in the [release notes](https://github.com/xspec/xspec/releases/tag/v3.2.2).


### PR DESCRIPTION
This PR adds a new post to promote the XSpec v3.2.2 release. I'll change this from Draft to Ready when the actual release is public, to avoid premature announcement.

I generated a local copy from the branch using `C:/Hugo/bin/hugo server -D  --buildFuture` and took some screen captures.

CC: @cmarchand, @cirulls , @rolfkleef , @AirQuick 


### Main page
![image](https://github.com/user-attachments/assets/ff7dccc5-0f69-419e-96f9-a5cc106bbbd2)

### New post
![image](https://github.com/user-attachments/assets/c8b907a9-6fb2-4d9f-80bd-b1acd782ebe4)

### List of versions
![image](https://github.com/user-attachments/assets/221d8756-d816-493a-98b8-be72409727be)
