### PR TITLE
Oxygen add-on for XSpec v3.3.1

### DIFF
--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -16,6 +16,19 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.3.1</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>You can execute an XSpec test for XSLT or XQuery using an XProc 3 pipeline (<a href="https://github.com/xspec/xspec/pull/2127"
+							>#2127</a>)</li>
+					<li>You can execute an XSpec test for a Schematron schema that has an XQuery-based queryBinding, using XQS as the Schematron implementation (<a href="https://github.com/xspec/xspec/pull/2157"
+							>#2157</a>)</li>
+					<li> In the x:expect element, the new, optional 'result-type' attribute describes the sequence type you expect for the actual result). XSpec checks the type before evaluating @test, so an unexpected type leads to an ordinary failure instead of a type error. (<a href="https://github.com/xspec/xspec/pull/2122"
+							>#2122</a>)</li>
+					<li>Tested with BaseX 12.0</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.2.2</h3>
 				<ul>
 					<li>Official release of v3.2</li>
@@ -71,18 +84,6 @@
 				<h3>v3.0.3</h3>
 				<ul>
 					<li>Official release of v3.0</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v3.0.2</h3>
-				<ul>
-					<li>Release Candidate of the stable release</li>
-					<li>feat(xslt): code coverage for Saxon 12.4+ (<a href="https://github.com/xspec/xspec/pull/1833"
-							>#1833</a>)</li>
-					<li>Removes Saxon 9.9 support</li>
-					<li>Saxon versions earlier than 12.4 are no longer recommended</li>
-					<li>Tested with Saxon 10.9, 11.6, and 12.4</li>
-					<li>Tested with Oxygen 26.1</li>
 				</ul>
 			</div>
 		</div>

--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -23,7 +23,7 @@
 							>#2127</a>)</li>
 					<li>You can execute an XSpec test for a Schematron schema that has an XQuery-based queryBinding, using XQS as the Schematron implementation (<a href="https://github.com/xspec/xspec/pull/2157"
 							>#2157</a>)</li>
-					<li> In the x:expect element, the new, optional 'result-type' attribute describes the sequence type you expect for the actual result). XSpec checks the type before evaluating @test, so an unexpected type leads to an ordinary failure instead of a type error. (<a href="https://github.com/xspec/xspec/pull/2122"
+					<li>In the x:expect element, the new, optional 'result-type' attribute describes the sequence type you expect for the actual result. XSpec checks the type before evaluating @test, so an unexpected type leads to an ordinary failure instead of a type error. (<a href="https://github.com/xspec/xspec/pull/2122"
 							>#2122</a>)</li>
 					<li>Tested with BaseX 12.0</li>
 				</ul>

--- a/static/editors/oxygen/oxygen-addon.xml
+++ b/static/editors/oxygen/oxygen-addon.xml
@@ -14,9 +14,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/refs/tags/v3.2.2.zip" />
+			href="https://github.com/xspec/xspec/archive/refs/tags/v3.3.1.zip" />
 
-		<xt:version>3.2.2</xt:version>
+		<xt:version>3.3.1</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
This pull request brings the Oxygen add-on up to date with https://github.com/xspec/xspec/pull/2165.

### To do, in this order:

- [x] Merge https://github.com/xspec/xspec/pull/2165 into `master`. That will create the v3.3.1.zip file.
- [x] On the branch for this PR, run hugo locally and test installation of the add-on with local URL: http://localhost:1313/editors/oxygen/oxygen-addon.xml
- [x] Merge this PR onto `hugo` branch.
- [x] Uninstall add-on, and test re-installation with remote URL: https://xspec.io/editors/oxygen/oxygen-addon.xml

Cc: @cmarchand 