### PR TITLE
Oxygen add-on for XSpec v3.4.2

### DIFF
--- a/static/editors/oxygen/latest.xhtml
+++ b/static/editors/oxygen/latest.xhtml
@@ -16,6 +16,15 @@
 		<div>
 			<h2 style="margin-top: 8mm">Changelog (not inclusive)</h2>
 			<div>
+				<h3>v3.4.2</h3>
+				<ul>
+					<li>Release Candidate of the stable release</li>
+					<li>Ant and the "Run XSpec Test" transformation scenario support running tests for Schematron schemas using XQS as the Schematron implementation. You must install BaseX and use the xspec.basex.classpath property (Parameters tab in Edit Ant Scenario dialog) to indicate the location of BaseX.jar.</li>
+					<li>Tested with XML Calabash 3.0.40.</li>
+					<li>Tested with BaseX 12.2.</li>
+				</ul>
+			</div>
+			<div>
 				<h3>v3.4.1</h3>
 				<ul>
 					<li>Requires Java 17 or later. XSpec is tested with Java 17 and 21.</li>
@@ -23,6 +32,7 @@
 					<li>The built-in XQuery-based Schematron implementation, XQS, is now v1.1.5.</li>
 					<li>The XProc-based Oxygen transformation scenarios for running XSpec tests for XSLT and XQuery now use XProc 3 instead of XProc 1.</li>
 					<li>Tested with Oxygen 28.0. This add-on requires Oxygen 28.0 or later, due to the XProc 3 scenarios.</li>
+					<li>After x:context or x:call, the x:variable and x:like elements can appear in any order and can be mixed.</li>
 					<li>Tested with BaseX 12.1.</li>
 					<li>Tested with Saxon 12.9 and 11.7. XSpec no longer supports Saxon 10.</li>
 				</ul>
@@ -80,12 +90,6 @@
 					<li>Fix for <a href="https://github.com/xspec/xspec-maven-plugin-1/">xspec/xspec-maven-plugin-1</a> and other uses
 						of XSpec from a .zip or .jar file</li>
 					<li>SchXslt 1.10.1 replaces 1.10 as the built-in Schematron implementation</li>
-				</ul>
-			</div>
-			<div>
-				<h3>v3.1.2</h3>
-				<ul>
-					<li>Official release of v3.1</li>
 				</ul>
 			</div>
 		</div>

--- a/static/editors/oxygen/oxygen-addon.xml
+++ b/static/editors/oxygen/oxygen-addon.xml
@@ -14,9 +14,9 @@
 			* Update the changelog in xt:description
 		-->
 		<xt:location
-			href="https://github.com/xspec/xspec/archive/refs/tags/v3.4.1.zip" />
+			href="https://github.com/xspec/xspec/archive/refs/tags/v3.4.2.zip" />
 
-		<xt:version>3.4.1</xt:version>
+		<xt:version>3.4.2</xt:version>
 
 		<!-- Note that supporting multiple oXygen versions may be hard to maintain, because
 			* oXygen add-on and framework require manual testing.


### PR DESCRIPTION
This pull request creates the Oxygen add-on for XSpec v3.4.2, the release candidate.

(In the description, the phrasing is a little different from the draft XSpec v3.4 release notes only because this change description distinguishes between 3.4.1 and 3.4.2, whereas the v3.4 release notes don't.)

### To do, in this order:

- [x] Merge https://github.com/xspec/xspec/pull/2273 into `master`. That will create the v3.4.2.zip file.
- [x] On the branch for this PR, run hugo locally and test installation of the add-on with local URL: http://localhost:1313/editors/oxygen/oxygen-addon.xml (To check that opening `xspec.xpr` in your own clone disables the add-on and enables its own framework, you have to sync your clone to `master`.)
- [x] Merge this PR onto `hugo` branch.
- [x] Uninstall add-on, and test re-installation with remote URL: https://xspec.io/editors/oxygen/oxygen-addon.xml

Cc: @cmarchand 