### PR TITLE
Update name of xspec/xspec default branch

### DIFF
--- a/content/contribute/index.md
+++ b/content/contribute/index.md
@@ -1,5 +1,5 @@
 +++
 title = "Contribute"
 +++
-If you wish to contribute to XSpec, please read the [contributing guidelines](https://github.com/xspec/xspec/blob/master/CONTRIBUTING.md) and then [raise or pick up an issue](https://github.com/xspec/xspec/issues) and [send us your pull requests](https://github.com/xspec/xspec/pulls). Please document any issue with examples of your XSpec code.
+If you wish to contribute to XSpec, please read the [contributing guidelines](https://github.com/xspec/xspec/blob/main/CONTRIBUTING.md) and then [raise or pick up an issue](https://github.com/xspec/xspec/issues) and [send us your pull requests](https://github.com/xspec/xspec/pulls). Please document any issue with examples of your XSpec code.
 


### PR DESCRIPTION
In case GitHub ever stops automatically redirecting `master` to `main` in links that point to branches, we should use the branch name `main`.